### PR TITLE
Refactor nav to use category list and fix lint issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -497,24 +497,13 @@ const App = () => {
 
               <div className="nav-categories">
                 <ul>
-                  <li><Link to="/portfolio" onClick={() => setIsNavOpen(false)}>Portfolio</Link></li>
-                  <li><Link to="/lead-capture" onClick={() => setIsNavOpen(false)}>Lead Capture</Link></li>
-                  <li><Link to="/click-through" onClick={() => setIsNavOpen(false)}>Click-Through</Link></li>
-                  <li><Link to="/product-sales-page" onClick={() => setIsNavOpen(false)}>Product / Sales</Link></li>
-                  <li><Link to="/e-book" onClick={() => setIsNavOpen(false)}>E-Book</Link></li>
-                  <li><Link to="/webinar" onClick={() => setIsNavOpen(false)}>Webinar Registration</Link></li>
-                  <li><Link to="/event-registration" onClick={() => setIsNavOpen(false)}>Event Registration</Link></li>
-                  <li><Link to="/get-started" onClick={() => setIsNavOpen(false)}>Get Started / Onboarding</Link></li>
-                  <li><Link to="/course" onClick={() => setIsNavOpen(false)}>Course / Membership</Link></li>
-                  <li><Link to="/membership" onClick={() => setIsNavOpen(false)}>Membership</Link></li>
-                  <li><Link to="/microsite" onClick={() => setIsNavOpen(false)}>Microsite</Link></li>
-                  <li><Link to="/coming-soon" onClick={() => setIsNavOpen(false)}>Coming Soon</Link></li>
-                  <li><Link to="/splash" onClick={() => setIsNavOpen(false)}>Splash Page</Link></li>
-                  <li><Link to="/squeeze-page" onClick={() => setIsNavOpen(false)}>Squeeze Page</Link></li>
-                  <li><Link to="/thank-you" onClick={() => setIsNavOpen(false)}>Thank You Page</Link></li>
-                  <li><Link to="/unsubscribe" onClick={() => setIsNavOpen(false)}>Unsubscribe Page</Link></li>
-                  <li><Link to="/404" onClick={() => setIsNavOpen(false)}>404 / Utility</Link></li>
-                  <li><Link to="/pricing" onClick={() => setIsNavOpen(false)}>Pricing</Link></li>
+                  {categories.map((category) => (
+                    <li key={category.path}>
+                      <Link to={category.path} onClick={() => setIsNavOpen(false)}>
+                        {category.name}
+                      </Link>
+                    </li>
+                  ))}
                 </ul>
               </div>
 

--- a/src/pages/get-started/ServiceSetup.jsx
+++ b/src/pages/get-started/ServiceSetup.jsx
@@ -68,7 +68,7 @@ const ServiceSetup = () => {
   ];
   
   const handleInputChange = (e) => {
-    const { name, value, type, checked } = e.target;
+    const { name, value, checked } = e.target;
     
     if (name === 'goals') {
       let updatedGoals = [...formData.goals];

--- a/src/pages/microsite/CampaignMicrosite.jsx
+++ b/src/pages/microsite/CampaignMicrosite.jsx
@@ -5,7 +5,7 @@ const CampaignMicrosite = () => {
   const [email, setEmail] = useState('');
   const [isSubscribed, setIsSubscribed] = useState(false);
   const [currentTestimonial, setCurrentTestimonial] = useState(0);
-  const [progress, setProgress] = useState(75); // Campaign progress percentage
+  const [progress] = useState(75); // Campaign progress percentage
 
   const testimonials = [
     {

--- a/src/pages/thank-you/FuturisticHologramThanks.jsx
+++ b/src/pages/thank-you/FuturisticHologramThanks.jsx
@@ -8,7 +8,7 @@ const FuturisticHologramThanks = () => {
   useEffect(() => {
     // Glitch effect for title
     const glitchInterval = setInterval(() => {
-      const glitchChars = ['THANK YOU', 'TH4NK Y0U', 'THA|\|K YOU', 'THANK YOU'];
+      const glitchChars = ['THANK YOU', 'TH4NK Y0U', 'THA|\\|K YOU', 'THANK YOU'];
       const randomIndex = Math.floor(Math.random() * glitchChars.length);
       setGlitchText(glitchChars[randomIndex]);
       


### PR DESCRIPTION
## Summary
- render bottom navigation links from the existing `categories` array to remove duplication
- clean up unused variables in several pages
- correct glitch string in futuristic thank-you page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e30f35d08333b4c1f378be068678